### PR TITLE
fix: base node path of. current working directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import Serverless from "serverless";
 import { ServerlessPluginCommand } from "../types/serverless-plugin-command";
 
-const NODE_MODULES_PATH = join(__dirname, "..", "./node_modules/.bin");
+const NODE_MODULES_PATH = join(process.cwd(), "./node_modules/.bin");
 
 interface SeverlessOfflineSesLocalOptions {
   stages?: string[];


### PR DESCRIPTION
Thanks for creating this!

The package resolves to the wrong path for the node modules bin path. Suggestion is to starting from the current working directory since serverless is most likely to be run from the directory where the user's `package.json` is located.